### PR TITLE
update to latest buildroot version 2014.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN            DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get insta
                     gnupg \
                     python \
                     libc6-i386 \
-                    language-pack-en-base
+                    language-pack-en-base \
+                    git-core
 WORKDIR        /tmp
 RUN            wget -nv http://buildroot.uclibc.org/downloads/buildroot-$BR_VERSION.tar.gz
 RUN            tar -zxf buildroot-$BR_VERSION.tar.gz && mv buildroot-$BR_VERSION buildroot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM           ubuntu:trusty
 MAINTAINER     Jeff Lindsay <progrium@gmail.com>
 
-ENV            BR_VERSION 2014.02
+ENV            BR_VERSION 2014.11
 RUN            DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y \
                     wget \
                     build-essential \

--- a/example/config
+++ b/example/config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Buildroot 2014.02 Configuration
+# Buildroot 2014.11 Configuration
 #
 BR2_HAVE_DOT_CONFIG=y
 
@@ -13,7 +13,6 @@ BR2_ARCH_IS_64=y
 # BR2_arm is not set
 # BR2_armeb is not set
 # BR2_aarch64 is not set
-# BR2_avr32 is not set
 # BR2_bfin is not set
 # BR2_i386 is not set
 # BR2_microblazeel is not set
@@ -24,6 +23,8 @@ BR2_ARCH_IS_64=y
 # BR2_mips64el is not set
 # BR2_nios2 is not set
 # BR2_powerpc is not set
+# BR2_powerpc64 is not set
+# BR2_powerpc64le is not set
 # BR2_sh is not set
 # BR2_sh64 is not set
 # BR2_sparc is not set
@@ -31,8 +32,12 @@ BR2_x86_64=y
 # BR2_xtensa is not set
 BR2_ARCH="x86_64"
 BR2_ENDIAN="LITTLE"
-BR2_GCC_TARGET_TUNE="generic"
-BR2_x86_generic=y
+BR2_GCC_TARGET_ARCH="nocona"
+BR2_ARCH_HAS_ATOMICS=y
+BR2_X86_CPU_HAS_MMX=y
+BR2_X86_CPU_HAS_SSE=y
+BR2_X86_CPU_HAS_SSE2=y
+BR2_X86_CPU_HAS_SSE3=y
 # BR2_x86_i386 is not set
 # BR2_x86_i486 is not set
 # BR2_x86_i586 is not set
@@ -44,8 +49,9 @@ BR2_x86_generic=y
 # BR2_x86_pentium3 is not set
 # BR2_x86_pentium4 is not set
 # BR2_x86_prescott is not set
-# BR2_x86_nocona is not set
+BR2_x86_nocona=y
 # BR2_x86_core2 is not set
+# BR2_x86_corei7 is not set
 # BR2_x86_atom is not set
 # BR2_x86_k6 is not set
 # BR2_x86_k6_2 is not set
@@ -90,16 +96,15 @@ BR2_HOST_DIR="$(BASE_DIR)/host"
 #
 BR2_PRIMARY_SITE=""
 BR2_BACKUP_SITE="http://sources.buildroot.net"
-BR2_KERNEL_MIRROR="http://www.kernel.org/pub"
+BR2_KERNEL_MIRROR="https://www.kernel.org/pub"
 BR2_GNU_MIRROR="http://ftp.gnu.org/pub/gnu"
-BR2_DEBIAN_MIRROR="http://ftp.debian.org"
-BR2_LUAROCKS_MIRROR="http://luarocks.org/repositories/rocks"
+BR2_LUAROCKS_MIRROR="http://rocks.moonscript.org"
+BR2_CPAN_MIRROR="http://cpan.metacpan.org"
 BR2_JLEVEL=0
 # BR2_CCACHE is not set
 # BR2_DEPRECATED is not set
 # BR2_ENABLE_DEBUG is not set
 BR2_STRIP_strip=y
-# BR2_STRIP_sstrip is not set
 # BR2_STRIP_none is not set
 BR2_STRIP_EXCLUDE_FILES=""
 BR2_STRIP_EXCLUDE_DIRS=""
@@ -108,51 +113,68 @@ BR2_STRIP_EXCLUDE_DIRS=""
 # BR2_OPTIMIZE_2 is not set
 # BR2_OPTIMIZE_3 is not set
 BR2_OPTIMIZE_S=y
-# BR2_ENABLE_SSP is not set
+
+#
+# enabling Stack Smashing Protection requires support in the toolchain
+#
 # BR2_PREFER_STATIC_LIB is not set
-BR2_PACKAGE_OVERRIDE_FILE="$(TOPDIR)/local.mk"
+BR2_PACKAGE_OVERRIDE_FILE="$(CONFIG_DIR)/local.mk"
 BR2_GLOBAL_PATCH_DIR=""
 
 #
 # Toolchain
 #
-BR2_TOOLCHAIN_USES_GLIBC=y
+BR2_TOOLCHAIN=y
+BR2_TOOLCHAIN_USES_UCLIBC=y
 BR2_TOOLCHAIN_BUILDROOT=y
 # BR2_TOOLCHAIN_EXTERNAL is not set
+BR2_TOOLCHAIN_BUILDROOT_VENDOR="buildroot"
 
 #
 # Kernel Header Options
 #
-# BR2_KERNEL_HEADERS_3_0 is not set
 # BR2_KERNEL_HEADERS_3_2 is not set
 # BR2_KERNEL_HEADERS_3_4 is not set
 # BR2_KERNEL_HEADERS_3_10 is not set
-# BR2_KERNEL_HEADERS_3_11 is not set
 # BR2_KERNEL_HEADERS_3_12 is not set
-BR2_KERNEL_HEADERS_3_13=y
+# BR2_KERNEL_HEADERS_3_14 is not set
+# BR2_KERNEL_HEADERS_3_16 is not set
+BR2_KERNEL_HEADERS_3_17=y
 # BR2_KERNEL_HEADERS_VERSION is not set
-# BR2_KERNEL_HEADERS_SNAP is not set
-BR2_DEFAULT_KERNEL_HEADERS="3.13.5"
-# BR2_TOOLCHAIN_BUILDROOT_UCLIBC is not set
+BR2_DEFAULT_KERNEL_HEADERS="3.17.4"
+BR2_TOOLCHAIN_BUILDROOT_UCLIBC=y
 # BR2_TOOLCHAIN_BUILDROOT_EGLIBC is not set
-BR2_TOOLCHAIN_BUILDROOT_GLIBC=y
-BR2_TOOLCHAIN_BUILDROOT_LIBC="glibc"
-# BR2_UCLIBC_VERSION_0_9_32 is not set
-# BR2_UCLIBC_VERSION_0_9_33 is not set
+# BR2_TOOLCHAIN_BUILDROOT_GLIBC is not set
+# BR2_TOOLCHAIN_BUILDROOT_MUSL is not set
+BR2_TOOLCHAIN_BUILDROOT_LIBC="uclibc"
+BR2_PACKAGE_UCLIBC=y
+
+#
+# uClibc Options
+#
+BR2_UCLIBC_VERSION_0_9_33=y
 # BR2_UCLIBC_VERSION_SNAPSHOT is not set
+BR2_UCLIBC_VERSION_STRING="0.9.33.2"
+BR2_UCLIBC_CONFIG="package/uclibc/uClibc-0.9.33.config"
+# BR2_TOOLCHAIN_BUILDROOT_LARGEFILE is not set
+# BR2_TOOLCHAIN_BUILDROOT_INET_IPV6 is not set
+# BR2_TOOLCHAIN_BUILDROOT_INET_RPC is not set
+# BR2_TOOLCHAIN_BUILDROOT_WCHAR is not set
+# BR2_TOOLCHAIN_BUILDROOT_LOCALE is not set
 # BR2_PTHREADS_NONE is not set
 # BR2_PTHREADS is not set
 # BR2_PTHREADS_OLD is not set
-# BR2_PTHREADS_NATIVE is not set
+BR2_PTHREADS_NATIVE=y
+# BR2_PTHREAD_DEBUG is not set
+# BR2_TOOLCHAIN_BUILDROOT_USE_SSP is not set
+BR2_UCLIBC_INSTALL_UTILS=y
+# BR2_UCLIBC_INSTALL_TEST_SUITE is not set
+BR2_UCLIBC_TARGET_ARCH="x86_64"
 
 #
 # Binutils Options
 #
-# BR2_BINUTILS_VERSION_2_20_1 is not set
-# BR2_BINUTILS_VERSION_2_21 is not set
-# BR2_BINUTILS_VERSION_2_21_1 is not set
 BR2_BINUTILS_VERSION_2_22=y
-# BR2_BINUTILS_VERSION_2_23_1 is not set
 # BR2_BINUTILS_VERSION_2_23_2 is not set
 # BR2_BINUTILS_VERSION_2_24 is not set
 BR2_BINUTILS_VERSION="2.22"
@@ -162,36 +184,48 @@ BR2_BINUTILS_EXTRA_CONFIG_OPTIONS=""
 # GCC Options
 #
 BR2_GCC_NEEDS_MPC=y
-# BR2_GCC_VERSION_4_3_X is not set
-# BR2_GCC_VERSION_4_4_X is not set
+BR2_GCC_SUPPORTS_GRAPHITE=y
 # BR2_GCC_VERSION_4_5_X is not set
-# BR2_GCC_VERSION_4_6_X is not set
-BR2_GCC_VERSION_4_7_X=y
-# BR2_GCC_VERSION_4_8_X is not set
-# BR2_GCC_VERSION_SNAP is not set
+# BR2_GCC_VERSION_4_7_X is not set
+BR2_GCC_VERSION_4_8_X=y
+# BR2_GCC_VERSION_4_9_X is not set
 BR2_GCC_SUPPORTS_FINEGRAINEDMTUNE=y
-BR2_GCC_VERSION="4.7.3"
+BR2_GCC_VERSION="4.8.3"
 BR2_EXTRA_GCC_CONFIG_OPTIONS=""
 # BR2_TOOLCHAIN_BUILDROOT_CXX is not set
 BR2_GCC_ENABLE_TLS=y
 # BR2_GCC_ENABLE_OPENMP is not set
 # BR2_GCC_ENABLE_LIBMUDFLAP is not set
+# BR2_GCC_ENABLE_GRAPHITE is not set
 # BR2_PACKAGE_HOST_GDB is not set
-BR2_LARGEFILE=y
-BR2_INET_IPV6=y
-BR2_TOOLCHAIN_HAS_NATIVE_RPC=y
-BR2_USE_WCHAR=y
-BR2_ENABLE_LOCALE=y
 BR2_TOOLCHAIN_HAS_THREADS=y
-BR2_TOOLCHAIN_HAS_THREADS_DEBUG=y
+BR2_TOOLCHAIN_HAS_THREADS_NPTL=y
 BR2_TOOLCHAIN_HAS_SHADOW_PASSWORDS=y
-BR2_TOOLCHAIN_HAS_SSP=y
 # BR2_ENABLE_LOCALE_PURGE is not set
-BR2_GENERATE_LOCALE=""
+BR2_NEEDS_GETTEXT=y
 BR2_USE_MMU=y
 BR2_TARGET_OPTIMIZATION="-pipe"
 BR2_TARGET_LDFLAGS=""
 # BR2_ECLIPSE_REGISTER is not set
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_0=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_1=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_2=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_3=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_4=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_5=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_6=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_7=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_8=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_9=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_10=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_11=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_12=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_13=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_14=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_15=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_16=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST_3_17=y
+BR2_TOOLCHAIN_HEADERS_AT_LEAST="3.17"
 
 #
 # System configuration
@@ -207,17 +241,27 @@ BR2_INIT_BUSYBOX=y
 # BR2_INIT_SYSV is not set
 
 #
-# systemd needs udev /dev management and a toolchain w/ largefile, wchar, IPv6, threads
+# systemd needs an (e)glibc toolchain, headers >= 3.7
 #
 # BR2_INIT_NONE is not set
 # BR2_ROOTFS_DEVICE_CREATION_STATIC is not set
 BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_DEVTMPFS=y
 # BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_MDEV is not set
-# BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_UDEV is not set
+
+#
+# eudev needs a toolchain w/ largefile, wchar, dynamic library
+#
 BR2_ROOTFS_DEVICE_TABLE="system/device_table.txt"
 BR2_ROOTFS_SKELETON_DEFAULT=y
 # BR2_ROOTFS_SKELETON_CUSTOM is not set
 BR2_TARGET_GENERIC_ROOT_PASSWD=""
+BR2_SYSTEM_BIN_SH_BUSYBOX=y
+
+#
+# bash, dash, zsh need BR2_PACKAGE_BUSYBOX_SHOW_OTHERS
+#
+# BR2_SYSTEM_BIN_SH_NONE is not set
+BR2_SYSTEM_BIN_SH="/bin/busybox"
 BR2_TARGET_GENERIC_GETTY=y
 
 #
@@ -234,6 +278,8 @@ BR2_TARGET_GENERIC_GETTY_BAUDRATE="115200"
 BR2_TARGET_GENERIC_GETTY_TERM="vt100"
 BR2_TARGET_GENERIC_GETTY_OPTIONS=""
 BR2_TARGET_GENERIC_REMOUNT_ROOTFS_RW=y
+# BR2_TARGET_TZ_INFO is not set
+BR2_ROOTFS_USERS_TABLES=""
 BR2_ROOTFS_OVERLAY=""
 BR2_ROOTFS_POST_BUILD_SCRIPT=""
 BR2_ROOTFS_POST_IMAGE_SCRIPT=""
@@ -247,55 +293,124 @@ BR2_ROOTFS_POST_IMAGE_SCRIPT=""
 # Target packages
 #
 BR2_PACKAGE_BUSYBOX=y
-# BR2_BUSYBOX_VERSION_1_20_X is not set
-# BR2_BUSYBOX_VERSION_1_21_X is not set
-BR2_BUSYBOX_VERSION_1_22_X=y
-# BR2_PACKAGE_BUSYBOX_SNAPSHOT is not set
-BR2_BUSYBOX_VERSION="1.22.1"
-BR2_PACKAGE_BUSYBOX_CONFIG="package/busybox/busybox-1.22.x.config"
+BR2_PACKAGE_BUSYBOX_CONFIG="package/busybox/busybox.config"
 # BR2_PACKAGE_BUSYBOX_SHOW_OTHERS is not set
 # BR2_PACKAGE_BUSYBOX_WATCHDOG is not set
 
 #
 # Audio and video applications
 #
-# BR2_PACKAGE_ALSA_UTILS is not set
+
+#
+# alsa-utils needs a toolchain w/ largefile, threads
+#
 # BR2_PACKAGE_AUMIX is not set
 
 #
 # bellagio needs a toolchain w/ C++, threads, dynamic library
 #
+
+#
+# espeak needs a toolchain w/ C++, wchar, threads
+#
 # BR2_PACKAGE_FAAD2 is not set
-# BR2_PACKAGE_FFMPEG is not set
-# BR2_PACKAGE_FLAC is not set
-# BR2_PACKAGE_GSTREAMER is not set
-# BR2_PACKAGE_GSTREAMER1 is not set
+
+#
+# ffmpeg needs a toolchain w/ largefile, IPv6
+#
+
+#
+# flac needs a toolchain w/ wchar
+#
+
+#
+# flite needs a toolchain w/ wchar
+#
+
+#
+# gstreamer 0.10 needs a toolchain w/ wchar, threads
+#
+
+#
+# gstreamer 1.x needs a toolchain w/ wchar, threads
+#
+
+#
+# jack2 needs a toolchain w/ largefile, threads, C++
+#
 # BR2_PACKAGE_LAME is not set
 # BR2_PACKAGE_LIBVPX is not set
 # BR2_PACKAGE_MADPLAY is not set
 
 #
+# modplugtools needs a toolchain w/ C++
+#
+
+#
 # mpd needs a toolchain w/ C++, threads, wchar
 #
 # BR2_PACKAGE_MPG123 is not set
-# BR2_PACKAGE_MPLAYER is not set
+
+#
+# mplayer needs a toolchain w/ largefile
+#
 # BR2_PACKAGE_MUSEPACK is not set
+
+#
+# ncmpc needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_OPUS_TOOLS is not set
-# BR2_PACKAGE_PULSEAUDIO is not set
-# BR2_PACKAGE_TSTOOLS is not set
+
+#
+# pulseaudio needs a toolchain w/ wchar, largefile, threads
+#
+# BR2_PACKAGE_SOX is not set
+
+#
+# tstools needs a toolchain w/ largefile
+#
+
+#
+# twolame needs a toolchain w/ largefile
+#
+
+#
+# upmpdcli needs a toolchain w/ C++, largefile, threads
+#
 
 #
 # vlc needs a uclibc snapshot or (e)glibc toolchain w/ C++, largefile, wchar, threads
 #
 # BR2_PACKAGE_VORBIS_TOOLS is not set
 # BR2_PACKAGE_WAVPACK is not set
+BR2_PACKAGE_XBMC_ARCH_SUPPORTS=y
+
+#
+# xbmc needs a toolchain w/ C++, IPv6, largefile, threads, wchar
+#
+
+#
+# xbmc needs an OpenGL or an openGL ES and EGL backend
+#
 # BR2_PACKAGE_YAVTA is not set
+
+#
+# ympd needs a toolchain w/ threads, largefile
+#
 
 #
 # Compressors and decompressors
 #
 # BR2_PACKAGE_BZIP2 is not set
 # BR2_PACKAGE_INFOZIP is not set
+
+#
+# lz4 needs a toolchain w/ largefile
+#
+
+#
+# lzip needs a toolchain w/ C++, largefile
+#
 # BR2_PACKAGE_LZOP is not set
 # BR2_PACKAGE_XZ is not set
 
@@ -309,36 +424,68 @@ BR2_PACKAGE_BUSYBOX_CONFIG="package/busybox/busybox-1.22.x.config"
 # BR2_PACKAGE_CACHE_CALIBRATOR is not set
 # BR2_PACKAGE_DHRYSTONE is not set
 # BR2_PACKAGE_DMALLOC is not set
-# BR2_PACKAGE_DROPWATCH is not set
-# BR2_PACKAGE_DSTAT is not set
+
+#
+# dropwatch needs a toolchain w/ threads, wchar
+#
+
+#
+# dstat needs a toolchain w/ wchar, threads
+#
 
 #
 # duma needs a toolchain w/ C++, threads
 #
-# BR2_PACKAGE_FIO is not set
-# BR2_PACKAGE_GDB is not set
+
+#
+# fio needs a toolchain w/ largefile, threads
+#
+
+#
+# gdb/gdbserver needs a toolchain w/ threads, threads debug
+#
+BR2_PACKAGE_GOOGLE_BREAKPAD_ARCH_SUPPORTS=y
+
+#
+# google-breakpad requires an (e)glibc toolchain w/ C++ enabled
+#
 # BR2_PACKAGE_IOZONE is not set
 # BR2_PACKAGE_KEXEC is not set
 
 #
 # ktap needs a Linux kernel to be built
 #
-# BR2_PACKAGE_LATENCYTOP is not set
+
+#
+# latencytop needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_LMBENCH is not set
-# BR2_PACKAGE_LTP_TESTSUITE is not set
-# BR2_PACKAGE_LTRACE is not set
+
+#
+# ltp-testsuite needs a toolchain w/ IPv6, RPC, largefile, threads
+#
+
+#
+# ltrace needs toolchain w/ largefile, wchar, dynamic library
+#
 
 #
 # lttng-modules needs a Linux kernel to be built
 #
-# BR2_PACKAGE_LTTNG_TOOLS is not set
+
+#
+# lttng-tools needs a toolchain w/ largefile, threads, wchar
+#
 # BR2_PACKAGE_MEMSTAT is not set
 # BR2_PACKAGE_NETPERF is not set
 
 #
-# oprofile needs a toolchain w/ C++
+# oprofile needs a toolchain w/ C++, wchar
 #
-# BR2_PACKAGE_PAX_UTILS is not set
+
+#
+# pax-utils needs a toolchain w/ largefile
+#
 
 #
 # perf needs a toolchain w/ largefile and a Linux kernel to be built
@@ -347,22 +494,46 @@ BR2_PACKAGE_BUSYBOX_CONFIG="package/busybox/busybox-1.22.x.config"
 # BR2_PACKAGE_RAMSMP is not set
 # BR2_PACKAGE_RAMSPEED is not set
 # BR2_PACKAGE_RT_TESTS is not set
-# BR2_PACKAGE_STRACE is not set
+# BR2_PACKAGE_SPIDEV_TEST is not set
+
+#
+# strace needs a toolchain w/ largefile
+#
 # BR2_PACKAGE_STRESS is not set
-# BR2_PACKAGE_SYSPROF is not set
+
+#
+# sysprof needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_TINYMEMBENCH is not set
-# BR2_PACKAGE_TRACE_CMD is not set
+
+#
+# trace-cmd needs a toolchain w/ largefile, threads, dynamic library
+#
+# BR2_PACKAGE_TRINITY is not set
 # BR2_PACKAGE_VALGRIND is not set
 # BR2_PACKAGE_WHETSTONE is not set
 
 #
 # Development tools
 #
-# BR2_PACKAGE_BINUTILS is not set
 # BR2_PACKAGE_BSDIFF is not set
-# BR2_PACKAGE_CVS is not set
+
+#
+# cppunit needs a toolchain w/ C++, dynamic library
+#
+
+#
+# cvs needs a toolchain w/ wchar
+#
 # BR2_PACKAGE_FLEX is not set
-# BR2_PACKAGE_GIT is not set
+
+#
+# gettext needs a toolchain w/ wchar
+#
+
+#
+# git needs a toolchain w/ largefile
+#
 
 #
 # gperf needs a toolchain w/ C++
@@ -373,33 +544,101 @@ BR2_PACKAGE_BUSYBOX_CONFIG="package/busybox/busybox-1.22.x.config"
 # BR2_PACKAGE_PKGCONF is not set
 # BR2_PACKAGE_SSTRIP is not set
 # BR2_PACKAGE_SUBVERSION is not set
-# BR2_PACKAGE_TREE is not set
+
+#
+# tree needs a toolchain w/ wchar
+#
 # BR2_PACKAGE_YASM is not set
 
 #
 # Filesystem and flash utilities
 #
+
+#
+# btrfs-progs needs a toolchain w/ largefile, wchar, threads
+#
 # BR2_PACKAGE_CIFS_UTILS is not set
 # BR2_PACKAGE_CRAMFS is not set
-# BR2_PACKAGE_CURLFTPFS is not set
-# BR2_PACKAGE_DOSFSTOOLS is not set
-# BR2_PACKAGE_E2FSPROGS is not set
-# BR2_PACKAGE_ECRYPTFS_UTILS is not set
-# BR2_PACKAGE_EXFAT is not set
-# BR2_PACKAGE_EXFAT_UTILS is not set
-# BR2_PACKAGE_F2FS_TOOLS is not set
-# BR2_PACKAGE_FLASHBENCH is not set
-# BR2_PACKAGE_GENEXT2FS is not set
+
+#
+# curlftpfs needs a toolchain w/ largefile, wchar, threads, dynamic library
+#
+
+#
+# dosfstools needs a toolchain w/ largefile, wchar
+#
+
+#
+# e2fsprogs needs a toolchain w/ largefile, wchar
+#
+
+#
+# e2tools needs a toolchain w/ threads, largefile and wchar
+#
+
+#
+# ecryptfs-utils needs a toolchain w/ largefile, threads, wchar
+#
+
+#
+# exfat needs a toolchain w/ largefile, wchar, threads, dynamic library
+#
+
+#
+# exfat-utils needs a toolchain w/ largefile, wchar
+#
+
+#
+# f2fs-tools needs a toolchain w/ largefile, wchar
+#
+
+#
+# flashbench needs a toolchain w/ largefile
+#
+
+#
+# genext2fs needs a toolchain w/ largefile
+#
+# BR2_PACKAGE_GENPART is not set
 # BR2_PACKAGE_GENROMFS is not set
 # BR2_PACKAGE_MAKEDEVS is not set
-# BR2_PACKAGE_MMC_UTILS is not set
+
+#
+# mmc-utils needs a toolchain w/ largefile, headers >= 3.0
+#
 # BR2_PACKAGE_MTD is not set
-# BR2_PACKAGE_NFS_UTILS is not set
-# BR2_PACKAGE_NTFS_3G is not set
-# BR2_PACKAGE_SQUASHFS is not set
-# BR2_PACKAGE_SSHFS is not set
-# BR2_PACKAGE_UNIONFS is not set
-# BR2_PACKAGE_XFSPROGS is not set
+
+#
+# mtools needs a toolchain w/ wchar
+#
+
+#
+# nfs-utils needs a toolchain w/ largefile, threads
+#
+
+#
+# ntfs-3g needs a toolchain w/ largefile, wchar, threads
+#
+
+#
+# simicsfs needs a Linux kernel to be built
+#
+
+#
+# squashfs needs a toolchain w/ largefile, threads
+#
+
+#
+# sshfs needs a toolchain w/ largefile, wchar, threads, dynamic library
+#
+
+#
+# unionfs needs a toolchain w/ largefile, threads, dynamic library
+#
+
+#
+# xfsprogs needs a toolchain w/ largefile, wchar
+#
 
 #
 # Games
@@ -407,6 +646,7 @@ BR2_PACKAGE_BUSYBOX_CONFIG="package/busybox/busybox-1.22.x.config"
 # BR2_PACKAGE_GNUCHESS is not set
 # BR2_PACKAGE_LBREAKOUT2 is not set
 # BR2_PACKAGE_LTRIS is not set
+# BR2_PACKAGE_OPENTYRIAN is not set
 # BR2_PACKAGE_PRBOOM is not set
 
 #
@@ -418,8 +658,14 @@ BR2_PACKAGE_BUSYBOX_CONFIG="package/busybox/busybox-1.22.x.config"
 #
 # BR2_PACKAGE_FSWEBCAM is not set
 # BR2_PACKAGE_GNUPLOT is not set
-# BR2_PACKAGE_JHEAD is not set
-# BR2_PACKAGE_RRDTOOL is not set
+
+#
+# jhead needs a toolchain w/ wchar
+#
+
+#
+# rrdtool needs a toolchain w/ wchar
+#
 
 #
 # Graphic libraries
@@ -447,15 +693,25 @@ BR2_PACKAGE_BUSYBOX_CONFIG="package/busybox/busybox-1.22.x.config"
 #
 
 #
+# mesa3d needs udev /dev management and a toolchain w/ C++, largefile, NPTL
+#
+
+#
 # ocrad needs a toolchain w/ C++
 #
-# BR2_PACKAGE_PSPLASH is not set
+
+#
+# psplash needs a toolchain w/ wchar
+#
 # BR2_PACKAGE_SDL is not set
 
 #
 # Other GUIs
 #
-# BR2_PACKAGE_EFL is not set
+
+#
+# EFL needs a toolchain w/ wchar
+#
 
 #
 # qt needs a toolchain w/ C++, threads
@@ -463,13 +719,16 @@ BR2_PACKAGE_BUSYBOX_CONFIG="package/busybox/busybox-1.22.x.config"
 BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 
 #
-# Qt5 needs a toolchain w/ wchar, IPv6, threads, C++
+# Qt5 needs a toolchain w/ wchar, IPv6, NPTL, C++
 #
 
 #
-# weston needs udev and a toolchain w/ threads
+# weston needs udev and a toolchain w/ threads, dynamic library, headers >= 3.0
 #
-# BR2_PACKAGE_XORG7 is not set
+
+#
+# X.org needs a toolchain w/ wchar, threads, dynamic library
+#
 
 #
 # X applications
@@ -482,6 +741,7 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 #
 # X libraries and helper libraries
 #
+# BR2_PACKAGE_DEJAVU is not set
 # BR2_PACKAGE_LIBERATION is not set
 # BR2_PACKAGE_XKEYBOARD_CONFIG is not set
 
@@ -501,16 +761,46 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 # BR2_PACKAGE_UX500_FIRMWARE is not set
 # BR2_PACKAGE_ZD1211_FIRMWARE is not set
 # BR2_PACKAGE_ACPID is not set
-# BR2_PACKAGE_AVRDUDE is not set
-# BR2_PACKAGE_CDRKIT is not set
-# BR2_PACKAGE_CRYPTSETUP is not set
-# BR2_PACKAGE_CWIID is not set
+
+#
+# avrdude needs a toolchain w/ threads, largefile, wchar, dynamic library
+#
+
+#
+# bcache-tools needs udev /dev management and a toolchain w/ largefile, wchar
+#
+
+#
+# cdrkit needs a toolchain w/ largefile, headers >= 3.0
+#
+
+#
+# cryptsetup needs a toolchain w/ largefile, wchar, threads, dynamic library
+#
 # BR2_PACKAGE_DBUS is not set
 # BR2_PACKAGE_DMIDECODE is not set
-# BR2_PACKAGE_DMRAID is not set
-# BR2_PACKAGE_DVB_APPS is not set
-# BR2_PACKAGE_DVBSNOOP is not set
+
+#
+# dmraid needs a toolchain w/ largefile, threads, dynamic library
+#
+
+#
+# dvb-apps utils needs a toolchain w/ largefile, threads, headers >= 3.3
+#
+
+#
+# dvbsnoop needs a toolchain w/ largefile
+#
+# BR2_PACKAGE_DTV_SCAN_TABLES is not set
 # BR2_PACKAGE_EEPROG is not set
+
+#
+# eudev needs eudev /dev management
+#
+
+#
+# eudev needs a toolchain w/ largefile, wchar, dynamic library
+#
 # BR2_PACKAGE_EVEMU is not set
 # BR2_PACKAGE_EVTEST is not set
 # BR2_PACKAGE_FAN_CTRL is not set
@@ -526,13 +816,17 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 #
 # gptfdisk needs a toolchain w/ largefile, wchar, C++
 #
-# BR2_PACKAGE_GVFS is not set
+
+#
+# gvfs needs a toolchain w/ largefile, wchar, threads
+#
 # BR2_PACKAGE_HWDATA is not set
 # BR2_PACKAGE_I2C_TOOLS is not set
 # BR2_PACKAGE_INPUT_EVENT_DAEMON is not set
 # BR2_PACKAGE_INPUT_TOOLS is not set
 # BR2_PACKAGE_INTEL_MICROCODE is not set
 # BR2_PACKAGE_IOSTAT is not set
+# BR2_PACKAGE_IPMITOOL is not set
 # BR2_PACKAGE_IRDA_UTILS is not set
 # BR2_PACKAGE_IUCODE_TOOL is not set
 # BR2_PACKAGE_KBD is not set
@@ -543,14 +837,29 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 # lshw needs a toolchain w/ C++, largefile, wchar
 #
 # BR2_PACKAGE_LSUIO is not set
-# BR2_PACKAGE_LVM2 is not set
+
+#
+# lvm2 needs a toolchain w/ largefile, threads, dynamic library
+#
 # BR2_PACKAGE_MDADM is not set
 # BR2_PACKAGE_MEDIA_CTL is not set
-# BR2_PACKAGE_MEMTESTER is not set
-# BR2_PACKAGE_MINICOM is not set
+
+#
+# memtester needs a toolchain w/ largefile
+#
+
+#
+# minicom needs a toolchain w/ wchar
+#
 # BR2_PACKAGE_NANOCOM is not set
-# BR2_PACKAGE_NEARD is not set
-# BR2_PACKAGE_OFONO is not set
+
+#
+# neard needs a toolchain w/ wchar, threads
+#
+
+#
+# ofono needs a toolchain w/ wchar, threads
+#
 
 #
 # ola needs a toolchain w/ C++, threads, largefile, wchar
@@ -561,33 +870,51 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 #
 # openpowerlink needs a toolchain w/ C++, threads
 #
-# BR2_PACKAGE_PARTED is not set
+
+#
+# parted needs a toolchain w/ largefile, wchar
+#
 # BR2_PACKAGE_PCIUTILS is not set
 # BR2_PACKAGE_PICOCOM is not set
+# BR2_PACKAGE_PPS_TOOLS is not set
 # BR2_PACKAGE_RNG_TOOLS is not set
 # BR2_PACKAGE_SANE_BACKENDS is not set
 # BR2_PACKAGE_SDPARM is not set
 # BR2_PACKAGE_SETSERIAL is not set
-# BR2_PACKAGE_SG3_UTILS is not set
+
+#
+# sg3-utils needs a toolchain w/ largefile, threads
+#
+
+#
+# sispmctl needs a toolchain w/ threads, wchar
+#
 
 #
 # smartmontools needs a toolchain w/ C++
 #
-# BR2_PACKAGE_SMSTOOLS3 is not set
+
+#
+# smstools3 needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_SNOWBALL_HDMISERVICE is not set
 # BR2_PACKAGE_SREDIRD is not set
 # BR2_PACKAGE_STATSERIAL is not set
 # BR2_PACKAGE_SYSSTAT is not set
+
+#
+# targetcli-fb depends on Python
+#
 # BR2_PACKAGE_TI_UIM is not set
 # BR2_PACKAGE_TI_UTILS is not set
 # BR2_PACKAGE_UBOOT_TOOLS is not set
 
 #
-# udev needs udev /dev management and a toolchain w/ largefile, wchar, dynamic library
+# udisks needs udev /dev management
 #
 
 #
-# udisks needs udev /dev management and a toolchain w/ wchar, threads, dynamic library
+# udisks needs a toolchain w/ wchar, threads, dynamic library
 #
 # BR2_PACKAGE_USB_MODESWITCH is not set
 # BR2_PACKAGE_USB_MODESWITCH_DATA is not set
@@ -605,20 +932,40 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 # BR2_PACKAGE_ENSCRIPT is not set
 # BR2_PACKAGE_ERLANG is not set
 # BR2_PACKAGE_HASERL is not set
-# BR2_PACKAGE_JAMVM is not set
+
+#
+# jamvm needs a toolchain w/ IPv6
+#
 # BR2_PACKAGE_JIMTCL is not set
 # BR2_PACKAGE_LUA is not set
 # BR2_PACKAGE_LUAJIT is not set
+BR2_PACKAGE_MONO_ARCH_SUPPORTS=y
+
+#
+# mono needs a toolchain w/ IPv6, threads
+#
 
 #
 # nodejs needs a toolchain w/ C++, IPv6, largefile, threads
 #
 # BR2_PACKAGE_PERL is not set
 # BR2_PACKAGE_PHP is not set
-# BR2_PACKAGE_PYTHON is not set
-# BR2_PACKAGE_PYTHON3 is not set
-# BR2_PACKAGE_RUBY is not set
-# BR2_PACKAGE_TCL is not set
+
+#
+# python needs a toolchain w/ wchar, threads
+#
+
+#
+# python3 needs a toolchain w/ wchar, threads
+#
+
+#
+# ruby needs a toolchain w/ wchar, threads, dynamic library
+#
+
+#
+# tcl needs a toolchain w/ ipv6, threads
+#
 
 #
 # Libraries
@@ -649,19 +996,37 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 #
 # libmodplug needs a toolchain w/ C++
 #
-# BR2_PACKAGE_LIBMPD is not set
+
+#
+# libmpd needs a toolchain w/ wchar, threads
+#
+# BR2_PACKAGE_LIBMPDCLIENT is not set
 # BR2_PACKAGE_LIBREPLAYGAIN is not set
 # BR2_PACKAGE_LIBSAMPLERATE is not set
-# BR2_PACKAGE_LIBSNDFILE is not set
+
+#
+# libsndfile needs a toolchain w/ largefile
+#
+# BR2_PACKAGE_LIBSOXR is not set
 # BR2_PACKAGE_LIBVORBIS is not set
+
+#
+# mp4v2 needs a toolchain w/ C++
+#
+
+#
+# opencore-amr needs a toolchain w/ C++
+#
 # BR2_PACKAGE_OPUS is not set
 # BR2_PACKAGE_PORTAUDIO is not set
 # BR2_PACKAGE_SPEEX is not set
 
 #
-# taglib needs a toolchain w/ C++
+# taglib needs a toolchain w/ C++, wchar
 #
+# BR2_PACKAGE_TINYALSA is not set
 # BR2_PACKAGE_TREMOR is not set
+# BR2_PACKAGE_VO_AACENC is not set
 
 #
 # webrtc-audio-processing needs a toolchain w/ C++, threads
@@ -670,32 +1035,50 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 #
 # Compression and decompression
 #
-# BR2_PACKAGE_LIBARCHIVE is not set
+
+#
+# libarchive needs a toolchain w/ wchar
+#
 # BR2_PACKAGE_LZO is not set
 
 #
 # snappy needs a toolchain w/ C++
 #
-# BR2_PACKAGE_ZLIB is not set
+BR2_PACKAGE_ZLIB=y
 
 #
 # Crypto
 #
 # BR2_PACKAGE_BEECRYPT is not set
+BR2_PACKAGE_BOTAN_ARCH_SUPPORTS=y
+
+#
+# botan needs a toolchain w/ C++, threads
+#
 # BR2_PACKAGE_CA_CERTIFICATES is not set
 
 #
 # cryptodev needs a Linux kernel to be built
 #
-# BR2_PACKAGE_GNUTLS is not set
-# BR2_PACKAGE_LIBASSUAN is not set
+
+#
+# gnutls needs a toolchain w/ wchar
+#
+BR2_PACKAGE_LIBASSUAN=y
 # BR2_PACKAGE_LIBGCRYPT is not set
-# BR2_PACKAGE_LIBGPG_ERROR is not set
-# BR2_PACKAGE_LIBGPGME is not set
+BR2_PACKAGE_LIBGPG_ERROR=y
+BR2_PACKAGE_LIBGPGME=y
+# BR2_PACKAGE_LIBKSBA is not set
 # BR2_PACKAGE_LIBMCRYPT is not set
 # BR2_PACKAGE_LIBMHASH is not set
-# BR2_PACKAGE_LIBNSS is not set
-# BR2_PACKAGE_LIBSECRET is not set
+
+#
+# libnss needs a toolchain w/ largefile, threads
+#
+
+#
+# libsecret needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_LIBSHA1 is not set
 # BR2_PACKAGE_LIBSSH2 is not set
 # BR2_PACKAGE_NETTLE is not set
@@ -711,43 +1094,82 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 #
 # MySQL needs a toolchain w/ C++, threads
 #
-# BR2_PACKAGE_REDIS is not set
+
+#
+# postgresql needs a toolchain w/ glibc
+#
+
+#
+# redis needs a toolchain w/ largefile, threads
+#
 # BR2_PACKAGE_SQLCIPHER is not set
 # BR2_PACKAGE_SQLITE is not set
 
 #
 # Filesystem
 #
-# BR2_PACKAGE_GAMIN is not set
+
+#
+# gamin needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_LIBCONFIG is not set
 # BR2_PACKAGE_LIBCONFUSE is not set
-# BR2_PACKAGE_LIBFUSE is not set
+
+#
+# libfuse needs a toolchain w/ largefile, threads, dynamic library
+#
 # BR2_PACKAGE_LIBLOCKFILE is not set
-# BR2_PACKAGE_LIBNFS is not set
+
+#
+# libnfs needs a toolchain w/ RPC and LARGEFILE
+#
 # BR2_PACKAGE_LIBSYSFS is not set
 # BR2_PACKAGE_LOCKDEV is not set
 
 #
 # Graphics
 #
-# BR2_PACKAGE_ATK is not set
+
+#
+# atk needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_CAIRO is not set
 # BR2_PACKAGE_FONTCONFIG is not set
 # BR2_PACKAGE_FREETYPE is not set
 # BR2_PACKAGE_GD is not set
-# BR2_PACKAGE_GDK_PIXBUF is not set
+
+#
+# gdk-pixbuf needs a toolchain w/ wchar, threads
+#
 
 #
 # harfbuzz needs a toolchain w/ C++
 #
+# BR2_PACKAGE_HICOLOR_ICON_THEME is not set
 # BR2_PACKAGE_IMLIB2 is not set
 # BR2_PACKAGE_JASPER is not set
 # BR2_PACKAGE_JPEG is not set
 # BR2_PACKAGE_LCMS2 is not set
 # BR2_PACKAGE_LIBART is not set
 # BR2_PACKAGE_LIBDMTX is not set
+
+#
+# libdrm needs a toolchain w/ largefile, threads
+#
 # BR2_PACKAGE_LIBEXIF is not set
 # BR2_PACKAGE_LIBGEOTIFF is not set
+
+#
+# libglew depends on X.org and needs an OpenGL backend
+#
+
+#
+# libglu needs an OpenGL backend
+#
+
+#
+# libgtk3 needs a toolchain w/ wchar, threads, C++
+#
 # BR2_PACKAGE_LIBPNG is not set
 # BR2_PACKAGE_LIBQRENCODE is not set
 
@@ -764,7 +1186,15 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 # BR2_PACKAGE_LIBUNGIF is not set
 
 #
-# opencv needs a toolchain w/ C++, threads, wchar
+# libva needs a toolchain w/ largefile, threads, dynamic library
+#
+
+#
+# libva intel driver needs a toolchain w/ largefile, threads, dynamic library
+#
+
+#
+# opencv needs a toolchain w/ C++, NPTL, wchar
 #
 
 #
@@ -793,6 +1223,7 @@ BR2_PACKAGE_WEBKIT_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_CCID is not set
 # BR2_PACKAGE_DTC is not set
+# BR2_PACKAGE_GNU_EFI is not set
 
 #
 # lcdapi needs a toolchain w/ C++, threads
@@ -809,6 +1240,10 @@ BR2_PACKAGE_WEBKIT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBFREEFARE is not set
 # BR2_PACKAGE_LIBFTDI is not set
 # BR2_PACKAGE_LIBHID is not set
+
+#
+# libinput needs udev /dev management
+#
 # BR2_PACKAGE_LIBIQRF is not set
 # BR2_PACKAGE_LIBLLCP is not set
 
@@ -816,18 +1251,33 @@ BR2_PACKAGE_WEBKIT_ARCH_SUPPORTS=y
 # libmbim needs udev /dev management and a toolchain w/ wchar, threads
 #
 # BR2_PACKAGE_LIBNFC is not set
-# BR2_PACKAGE_LIBQMI is not set
+
+#
+# libpciaccess needs a toolchain w/ largefile
+#
+# BR2_PACKAGE_LIBPHIDGET is not set
+
+#
+# libqmi needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_LIBRAW1394 is not set
+# BR2_PACKAGE_LIBRTLSDR is not set
 
 #
 # libserial needs a toolchain w/ C++
 #
 # BR2_PACKAGE_LIBSOC is not set
 # BR2_PACKAGE_LIBUSB is not set
-# BR2_PACKAGE_LIBV4L is not set
+
+#
+# libv4l needs a toolchain w/ largefile, threads and C++, headers >= 3.0
+#
 # BR2_PACKAGE_LIBXKBCOMMON is not set
 # BR2_PACKAGE_MTDEV is not set
-# BR2_PACKAGE_NEARDAL is not set
+
+#
+# neardal needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_PCSC_LITE is not set
 # BR2_PACKAGE_TSLIB is not set
 
@@ -842,6 +1292,7 @@ BR2_PACKAGE_WEBKIT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_FLOT is not set
 # BR2_PACKAGE_JQUERY is not set
 # BR2_PACKAGE_JQUERY_KEYBOARD is not set
+# BR2_PACKAGE_JQUERY_MOBILE is not set
 # BR2_PACKAGE_JQUERY_SPARKLINE is not set
 # BR2_PACKAGE_JQUERY_UI is not set
 # BR2_PACKAGE_JQUERY_VALIDATION is not set
@@ -856,7 +1307,10 @@ BR2_PACKAGE_WEBKIT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_EZXML is not set
 # BR2_PACKAGE_JANSSON is not set
 # BR2_PACKAGE_JSON_C is not set
-# BR2_PACKAGE_JSON_GLIB is not set
+
+#
+# json-glib needs a toolchain w/ wchar, threads
+#
 
 #
 # libjson needs a toolchain w/ C++
@@ -867,6 +1321,7 @@ BR2_PACKAGE_WEBKIT_ARCH_SUPPORTS=y
 #
 # libxml++ needs a toolchain w/ C++, wchar, threads
 #
+# BR2_PACKAGE_LIBXMLRPC is not set
 # BR2_PACKAGE_LIBXSLT is not set
 # BR2_PACKAGE_LIBYAML is not set
 # BR2_PACKAGE_MXML is not set
@@ -882,16 +1337,45 @@ BR2_PACKAGE_WEBKIT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_YAJL is not set
 
 #
+# yaml-cpp needs a toolchain w/ C++, largefile, threads
+#
+
+#
+# Logging
+#
+# BR2_PACKAGE_LIBLOG4C_LOCALTIME is not set
+# BR2_PACKAGE_LIBLOGGING is not set
+
+#
+# log4cplus needs a toolchain w/ C++, wchar, threads
+#
+
+#
+# log4cxx needs a toolchain w/ C++, threads, dynamic library
+#
+
+#
+# zlog needs a toolchain w/ threads, largefile, dynamic library
+#
+
+#
 # Multimedia
 #
 # BR2_PACKAGE_LIBASS is not set
 # BR2_PACKAGE_LIBBLURAY is not set
+# BR2_PACKAGE_LIBDVBCSA is not set
 
 #
 # libdvbsi++ needs a toolchain w/ C++, wchar, threads
 #
-# BR2_PACKAGE_LIBDVDNAV is not set
-# BR2_PACKAGE_LIBDVDREAD is not set
+
+#
+# libdvdnav needs a toolchain w/ dynamic library, largefile, threads
+#
+
+#
+# libdvdread needs a toolchain w/ dynamic library, largefile
+#
 
 #
 # libebml needs a toolchain w/ C++
@@ -900,10 +1384,16 @@ BR2_PACKAGE_WEBKIT_ARCH_SUPPORTS=y
 #
 # libmatroska needs a toolchain w/ C++
 #
-# BR2_PACKAGE_LIBMMS is not set
+
+#
+# libmms needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_LIBMPEG2 is not set
 # BR2_PACKAGE_LIBOGG is not set
-# BR2_PACKAGE_LIBPLAYER is not set
+
+#
+# libplayer needs a toolchain w/ largefile, threads
+#
 # BR2_PACKAGE_LIBTHEORA is not set
 
 #
@@ -915,9 +1405,19 @@ BR2_PACKAGE_WEBKIT_ARCH_SUPPORTS=y
 #
 
 #
+# x264 needs a toolchain w/ largefile
+#
+
+#
 # Networking
 #
+
+#
+# agent++ needs a toolchain w/ threads, C++, dynamic library
+#
 # BR2_PACKAGE_C_ARES is not set
+BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
+# BR2_PACKAGE_CANFESTIVAL is not set
 
 #
 # cppzmq needs a toolchain w/ C++, IPv6, largefile, wchar, threads
@@ -930,7 +1430,12 @@ BR2_PACKAGE_WEBKIT_ARCH_SUPPORTS=y
 #
 # filemq needs a toolchain w/ C++, IPv6, largefile, wchar, threads
 #
-# BR2_PACKAGE_GLIB_NETWORKING is not set
+# BR2_PACKAGE_FLICKCURL is not set
+# BR2_PACKAGE_GEOIP is not set
+
+#
+# glib-networking needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_LIBCGI is not set
 
 #
@@ -938,39 +1443,85 @@ BR2_PACKAGE_WEBKIT_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_LIBCURL is not set
 # BR2_PACKAGE_LIBDNET is not set
-# BR2_PACKAGE_LIBESMTP is not set
 # BR2_PACKAGE_LIBEXOSIP2 is not set
 # BR2_PACKAGE_LIBFCGI is not set
 # BR2_PACKAGE_LIBGSASL is not set
 # BR2_PACKAGE_LIBIDN is not set
 # BR2_PACKAGE_LIBISCSI is not set
 # BR2_PACKAGE_LIBMBUS is not set
+
+#
+# libmemcached needs a toolchain w/ C++, threads
+#
 # BR2_PACKAGE_LIBMICROHTTPD is not set
-# BR2_PACKAGE_LIBMNL is not set
+
+#
+# libmnl needs a toolchain w/ largefile
+#
 # BR2_PACKAGE_LIBMODBUS is not set
-# BR2_PACKAGE_LIBNETFILTER_ACCT is not set
-# BR2_PACKAGE_LIBNETFILTER_CONNTRACK is not set
-# BR2_PACKAGE_LIBNETFILTER_CTHELPER is not set
-# BR2_PACKAGE_LIBNETFILTER_CTTIMEOUT is not set
+
+#
+# libndp needs a toolchain w/ IPv6
+#
+
+#
+# libnetfilter_acct needs a toolchain w/ largefile
+#
+
+#
+# libnetfilter_conntrack needs a toolchain w/ largefile
+#
+
+#
+# libnetfilter_cthelper needs a toolchain w/ largefile
+#
+
+#
+# libnetfilter_cttimout needs a toolchain w/ largefile
+#
 # BR2_PACKAGE_LIBNETFILTER_LOG is not set
-# BR2_PACKAGE_LIBNETFILTER_QUEUE is not set
+
+#
+# libnetfilter_queue needs a toolchain w/ largefile, IPv6
+#
 # BR2_PACKAGE_LIBNFNETLINK is not set
-# BR2_PACKAGE_LIBNFTNL is not set
+
+#
+# libnftnl needs a toolchain w/ threads, IPv6, largefile
+#
 # BR2_PACKAGE_LIBNL is not set
 # BR2_PACKAGE_LIBOAUTH is not set
-# BR2_PACKAGE_LIBOPING is not set
+
+#
+# liboping needs a toolchain w/ IPv6
+#
 # BR2_PACKAGE_LIBOSIP2 is not set
 # BR2_PACKAGE_LIBPCAP is not set
 # BR2_PACKAGE_LIBRSYNC is not set
 # BR2_PACKAGE_LIBSOCKETCAN is not set
-# BR2_PACKAGE_LIBSHAIRPLAY is not set
-# BR2_PACKAGE_LIBSOUP is not set
+
+#
+# libshairplay needs a toolchain w/ IPv6, threads, dynamic library
+#
+# BR2_PACKAGE_LIBSHOUT is not set
+
+#
+# libsoup needs a toolchain w/ wchar, threads
+#
+# BR2_PACKAGE_LIBSTROPHE is not set
 # BR2_PACKAGE_LIBTIRPC is not set
 
 #
 # libtorrent needs a toolchain w/ C++, threads
 #
-# BR2_PACKAGE_LIBUPNP is not set
+
+#
+# libupnp needs a toolchain w/ largefile, threads
+#
+
+#
+# libupnpp needs a toolchain w/ C++, largefile, threads
+#
 # BR2_PACKAGE_LIBVNCSERVER is not set
 # BR2_PACKAGE_LIBWEBSOCKETS is not set
 # BR2_PACKAGE_NEON is not set
@@ -978,13 +1529,17 @@ BR2_PACKAGE_WEBKIT_ARCH_SUPPORTS=y
 #
 # omniORB needs a toolchain w/ C++, threads
 #
-# BR2_PACKAGE_OPENPGM is not set
+
+#
+# openpgm needs a toolchain w/ wchar, threads, IPv6
+#
 # BR2_PACKAGE_ORTP is not set
+# BR2_PACKAGE_QDECODER is not set
 # BR2_PACKAGE_RTMPDUMP is not set
 # BR2_PACKAGE_SLIRP is not set
 
 #
-# snmp++ needs a toolchain w/ threads, C++
+# snmp++ needs a toolchain w/ threads, C++, dynamic library
 #
 
 #
@@ -1016,21 +1571,40 @@ BR2_PACKAGE_WEBKIT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_ARGP_STANDALONE is not set
 
 #
+# armadillo needs a toolchain w/ C++, largefile
+#
+
+#
 # boost needs a toolchain w/ C++, largefile, threads
 #
 
 #
-# cppcms needs an (e)glibc toolchain w/ C++
+# cblas/clapack needs a toolchain w/ largefile
+#
+
+#
+# cppcms needs a toolchain w/ C++, NPTL, wchar, dynamic library
 #
 
 #
 # eigen needs a toolchain w/ C++
 #
-# BR2_PACKAGE_ELFUTILS is not set
+
+#
+# elfutils needs a toolchain w/ largefile, wchar, dynamic library
+#
 # BR2_PACKAGE_FFTW is not set
 
 #
+# flann needs a toolchain w/ C++, dynamic library
+#
+
+#
 # glibmm needs a toolchain w/ C++, wchar, threads
+#
+
+#
+# glm needs a toolchain w/ C++
 #
 # BR2_PACKAGE_GMP is not set
 # BR2_PACKAGE_GSL is not set
@@ -1039,8 +1613,13 @@ BR2_PACKAGE_WEBKIT_ARCH_SUPPORTS=y
 # gtest needs a toolchain w/ C++, wchar, threads
 #
 # BR2_PACKAGE_LIBARGTABLE2 is not set
+BR2_PACKAGE_LIBATOMIC_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBATOMIC_OPS is not set
-# BR2_PACKAGE_LIBBSD is not set
+BR2_PACKAGE_LIBBSD_ARCH_SUPPORTS=y
+
+#
+# libbsd needs an (e)glibc toolchain w/ threads
+#
 # BR2_PACKAGE_LIBCAP is not set
 # BR2_PACKAGE_LIBCAP_NG is not set
 
@@ -1048,21 +1627,31 @@ BR2_PACKAGE_WEBKIT_ARCH_SUPPORTS=y
 # libcgroup needs an (e)glibc toolchain w/ C++
 #
 # BR2_PACKAGE_LIBDAEMON is not set
-# BR2_PACKAGE_LIBELF is not set
+# BR2_PACKAGE_LIBEE is not set
 # BR2_PACKAGE_LIBEV is not set
 # BR2_PACKAGE_LIBEVDEV is not set
 # BR2_PACKAGE_LIBEVENT is not set
 # BR2_PACKAGE_LIBFFI is not set
-# BR2_PACKAGE_LIBGLIB2 is not set
-# BR2_PACKAGE_LIBICAL is not set
-# BR2_PACKAGE_LIBLOG4C_LOCALTIME is not set
+# BR2_PACKAGE_LIBGC is not set
+
+#
+# libglib2 needs a toolchain w/ wchar, threads
+#
+
+#
+# libical needs a toolchain w/ wchar
+#
 BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
-# BR2_PACKAGE_LIBNSPR is not set
+
+#
+# libnspr needs a toolchain w/ largefile, threads
+#
 # BR2_PACKAGE_LIBPFM4 is not set
 
 #
 # libplist needs a toolchain w/ C++
 #
+# BR2_PACKAGE_LIBPTHREAD_STUBS is not set
 # BR2_PACKAGE_LIBPTHSEM is not set
 # BR2_PACKAGE_LIBSECCOMP is not set
 
@@ -1072,19 +1661,27 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_LIBSIGSEGV is not set
 # BR2_PACKAGE_LIBTASN1 is not set
 # BR2_PACKAGE_LIBTPL is not set
-# BR2_PACKAGE_LIBUNWIND is not set
+# BR2_PACKAGE_LIBUBOX is not set
+# BR2_PACKAGE_LIBUCI is not set
+
+#
+# libunwind needs a uclibc snapshot or (e)glibc toolchain w/ threads
+#
 # BR2_PACKAGE_LIBURCU is not set
-# BR2_PACKAGE_LINUX_PAM is not set
 
 #
-# log4cplus needs a toolchain w/ C++, wchar, threads
+# libuv needs a toolchain w/ IPv6, threads
 #
 
 #
-# log4cxx needs a toolchain w/ C++, threads, dynamic library
+# linux-pam needs a toolchain w/ wchar, locale, dynamic library
 #
-# BR2_PACKAGE_LTTNG_LIBUST is not set
+
+#
+# lttng-libust needs a toolchain w/ wchar, largefile, threads
+#
 # BR2_PACKAGE_MPC is not set
+# BR2_PACKAGE_MPDECIMAL is not set
 # BR2_PACKAGE_MPFR is not set
 
 #
@@ -1107,9 +1704,8 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 #
 
 #
-# schifra needs a toolchain w/ C++
+# qlibc needs a toolchain w/ threads, wchar, dynamic library
 #
-# BR2_PACKAGE_TZDATA is not set
 
 #
 # Security
@@ -1127,48 +1723,124 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 #
 # icu needs a toolchain w/ C++, wchar, threads
 #
-# BR2_PACKAGE_LIBEDIT is not set
+
+#
+# libedit needs a toolchain w/ wchar
+#
 # BR2_PACKAGE_LIBENCA is not set
+# BR2_PACKAGE_LIBESTR is not set
 # BR2_PACKAGE_LIBFRIBIDI is not set
+# BR2_PACKAGE_LIBICONV is not set
+# BR2_PACKAGE_LIBUNISTRING is not set
 # BR2_PACKAGE_LINENOISE is not set
-# BR2_PACKAGE_NCURSES is not set
-# BR2_PACKAGE_NEWT is not set
+BR2_PACKAGE_NCURSES=y
+# BR2_PACKAGE_NCURSES_TARGET_PANEL is not set
+# BR2_PACKAGE_NCURSES_TARGET_FORM is not set
+# BR2_PACKAGE_NCURSES_TARGET_MENU is not set
+# BR2_PACKAGE_NCURSES_TARGET_PROGS is not set
+
+#
+# newt needs a toolchain w/ wchar
+#
 # BR2_PACKAGE_PCRE is not set
 # BR2_PACKAGE_POPT is not set
 # BR2_PACKAGE_READLINE is not set
 # BR2_PACKAGE_SLANG is not set
 
 #
+# tclap needs a toolchain w/ C++
+#
+
+#
 # Miscellaneous
 #
 # BR2_PACKAGE_AESPIPE is not set
 # BR2_PACKAGE_BC is not set
-# BR2_PACKAGE_COLLECTD is not set
+# BR2_PACKAGE_CLAMAV is not set
+
+#
+# collectd needs a toolchain w/ IPv6, threads, dynamic library
+#
 # BR2_PACKAGE_EMPTY is not set
 # BR2_PACKAGE_GOOGLEFONTDIRECTORY is not set
 # BR2_PACKAGE_HAVEGED is not set
 # BR2_PACKAGE_MCRYPT is not set
 # BR2_PACKAGE_MOBILE_BROADBAND_PROVIDER_INFO is not set
-# BR2_PACKAGE_SHARED_MIME_INFO is not set
-# BR2_PACKAGE_SNOWBALL_INIT is not set
+
+#
+# QEMU requires a toolchain with IPv6, wchar, threads
+#
+
+#
+# shared-mime-info needs a toolchain w/ wchar, threads
+#
+
+#
+# snowball-init needs a toolchain w/ wchar, threads, dynamic library
+#
 # BR2_PACKAGE_SOUND_THEME_BOREALIS is not set
 # BR2_PACKAGE_SOUND_THEME_FREEDESKTOP is not set
 
 #
+# Mail
+#
+
+#
+# dovecot needs a toolchain w/ IPv6
+#
+# BR2_PACKAGE_EXIM is not set
+# BR2_PACKAGE_FETCHMAIL is not set
+# BR2_PACKAGE_HEIRLOOM_MAILX is not set
+# BR2_PACKAGE_LIBESMTP is not set
+# BR2_PACKAGE_MSMTP is not set
+
+#
+# mutt needs a toolchain w/ wchar
+#
+
+#
 # Networking applications
 #
-# BR2_PACKAGE_AICCU is not set
-# BR2_PACKAGE_AIRCRACK_NG is not set
-# BR2_PACKAGE_ARGUS is not set
+
+#
+# nginx needs a toolchain w/ largefile
+#
+
+#
+# aiccu needs a toolchain w/ IPv6, wchar, threads
+#
+
+#
+# aircrack-ng needs a toolchain w/ largefile, threads
+#
+
+#
+# argus needs a toolchain w/ threads, IPv6
+#
 # BR2_PACKAGE_ARPTABLES is not set
+
+#
+# atftp needs a toolchain w/ threads, IPv6
+#
 # BR2_PACKAGE_AVAHI is not set
 # BR2_PACKAGE_AXEL is not set
+# BR2_PACKAGE_BANDWIDTHD is not set
 
 #
 # bcusdk needs a toolchain w/ C++
 #
-# BR2_PACKAGE_BIND is not set
-# BR2_PACKAGE_BLUEZ_UTILS is not set
+
+#
+# bind needs a toolchain w/ largefile, IPv6, dynamic library
+#
+
+#
+# bluez-utils needs a toolchain w/ wchar, threads, dynamic library
+#
+
+#
+# bluez5-utils needs a toolchain w/ wchar, threads, IPv6, headers >= 3.4, dynamic library
+#
 # BR2_PACKAGE_BMON is not set
 # BR2_PACKAGE_BOA is not set
 # BR2_PACKAGE_BRIDGE_UTILS is not set
@@ -1176,8 +1848,14 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_CAN_UTILS is not set
 # BR2_PACKAGE_CHRONY is not set
 # BR2_PACKAGE_CIVETWEB is not set
-# BR2_PACKAGE_CONNMAN is not set
-# BR2_PACKAGE_CONNTRACK_TOOLS is not set
+
+#
+# connman needs a toolchain w/ IPv6, wchar, threads, resolver, dynamic library
+#
+
+#
+# conntrack-tools needs a toolchain w/ IPv6, largefile, threads
+#
 # BR2_PACKAGE_CRDA is not set
 
 #
@@ -1188,20 +1866,35 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_DHCPDUMP is not set
 # BR2_PACKAGE_DNSMASQ is not set
 # BR2_PACKAGE_DROPBEAR is not set
-# BR2_PACKAGE_EBTABLES is not set
+
+#
+# ebtables needs a toolchain w/ IPv6
+#
 # BR2_PACKAGE_ETHTOOL is not set
+# BR2_PACKAGE_FAIFA is not set
 # BR2_PACKAGE_FPING is not set
-# BR2_PACKAGE_GESFTPSERVER is not set
-# BR2_PACKAGE_HEIRLOOM_MAILX is not set
+
+#
+# gesftpserver needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_HIAWATHA is not set
 # BR2_PACKAGE_HOSTAPD is not set
-# BR2_PACKAGE_HTTPING is not set
-# BR2_PACKAGE_IFTOP is not set
+
+#
+# httping needs a toolchain w/ wchar
+#
+
+#
+# iftop needs a toolchain w/ IPv6, threads
+#
 
 #
 # igh-ethercat needs a Linux kernel to be built
 #
-# BR2_PACKAGE_IGMPPROXY is not set
+
+#
+# igmpproxy needs a toolchain w/ wchar
+#
 # BR2_PACKAGE_INADYN is not set
 
 #
@@ -1209,8 +1902,15 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 #
 # BR2_PACKAGE_IPROUTE2 is not set
 # BR2_PACKAGE_IPSEC_TOOLS is not set
-# BR2_PACKAGE_IPSET is not set
+
+#
+# ipset needs a toolchain w/ largefile
+#
 # BR2_PACKAGE_IPTABLES is not set
+
+#
+# iptraf-ng needs a toolchain w/ IPv6
+#
 # BR2_PACKAGE_IPUTILS is not set
 # BR2_PACKAGE_IW is not set
 
@@ -1218,6 +1918,7 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # kismet needs a toolchain w/ threads, C++
 #
 # BR2_PACKAGE_KNOCK is not set
+# BR2_PACKAGE_LEAFNODE2 is not set
 
 #
 # lftp requires a toolchain w/ C++, wchar
@@ -1232,35 +1933,54 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 #
 # linphone needs a toolchain w/ threads, C++, IPv6
 #
+# BR2_PACKAGE_LINUX_ZIGBEE is not set
 # BR2_PACKAGE_LRZSZ is not set
 # BR2_PACKAGE_MACCHANGER is not set
+# BR2_PACKAGE_MEMCACHED is not set
 # BR2_PACKAGE_MII_DIAG is not set
-# BR2_PACKAGE_MINIDLNA is not set
+
+#
+# minidlna needs a toolchain w/ largefile, IPv6, threads, wchar
+#
 
 #
 # modemmanager needs udev /dev management and a toolchain w/ largefile, wchar, threads, IPv6
 #
-# BR2_PACKAGE_MONGOOSE is not set
 
 #
-# mongrel2 needs a toolchain w/ C++, IPv6, threads, largefile, wchar
+# mongoose needs a toolchain w/ threads, largefile
 #
 # BR2_PACKAGE_MROUTED is not set
-# BR2_PACKAGE_MSMTP is not set
 # BR2_PACKAGE_MTR is not set
-# BR2_PACKAGE_MUTT is not set
-# BR2_PACKAGE_NBD is not set
+
+#
+# nbd needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_NCFTP is not set
-# BR2_PACKAGE_NDISC6 is not set
+
+#
+# ndisc6 needs a toolchain w/ IPv6
+#
 # BR2_PACKAGE_NETATALK is not set
 # BR2_PACKAGE_NETPLUG is not set
 # BR2_PACKAGE_NETSNMP is not set
 # BR2_PACKAGE_NETSTAT_NAT is not set
 
 #
-# NetworkManager needs udev /dev management and a toolchain w/ IPv6, largefile, wchar, threads
+# NetworkManager needs udev /dev management and a toolchain w/ IPv6, largefile, wchar, threads, headers >= 3.7
 #
-# BR2_PACKAGE_NFACCT is not set
+
+#
+# nfacct needs a toolchain w/ largefile
+#
+
+#
+# nftables needs a toolchain w/ IPv6, largefile, threads, wchar, headers >= 3.4
+#
+
+#
+# nginx needs a toolchain w/ largefile
+#
 # BR2_PACKAGE_NGIRCD is not set
 # BR2_PACKAGE_NGREP is not set
 
@@ -1270,22 +1990,40 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_NOIP is not set
 # BR2_PACKAGE_NTP is not set
 # BR2_PACKAGE_NUTTCP is not set
-# BR2_PACKAGE_OLSR is not set
+# BR2_PACKAGE_ODHCPLOC is not set
+
+#
+# olsr needs a toolchain w/ IPv6, threads
+#
 # BR2_PACKAGE_OPENNTPD is not set
-# BR2_PACKAGE_OPENOBEX is not set
+
+#
+# openobex needs a toolchain w/ IPv6
+#
 # BR2_PACKAGE_OPENSSH is not set
 # BR2_PACKAGE_OPENSWAN is not set
-# BR2_PACKAGE_OPENVPN is not set
+
+#
+# openvpn needs a toolchain w/ IPv6
+#
 # BR2_PACKAGE_P910ND is not set
-# BR2_PACKAGE_PORTMAP is not set
+# BR2_PACKAGE_PHIDGETWEBSERVICE is not set
+
+#
+# portmap needs a toolchain w/ RPC
+#
 # BR2_PACKAGE_PPPD is not set
 # BR2_PACKAGE_PPTP_LINUX is not set
 # BR2_PACKAGE_PROFTPD is not set
 # BR2_PACKAGE_PROXYCHAINS_NG is not set
 # BR2_PACKAGE_PTPD is not set
 # BR2_PACKAGE_PTPD2 is not set
+# BR2_PACKAGE_PURE_FTPD is not set
 # BR2_PACKAGE_QUAGGA is not set
-# BR2_PACKAGE_RADVD is not set
+
+#
+# radvd needs a toolchain w/ IPv6
+#
 # BR2_PACKAGE_RPCBIND is not set
 # BR2_PACKAGE_RSH_REDONE is not set
 # BR2_PACKAGE_RSYNC is not set
@@ -1297,13 +2035,28 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_SAMBA is not set
 
 #
-# sconeserver needs a toolchain w/ C++, threads
+# samba4 needs a toolchain w/ IPv6, wchar, largfile, threads
 #
-# BR2_PACKAGE_SER2NET is not set
-# BR2_PACKAGE_SMCROUTE is not set
+
+#
+# sconeserver needs a toolchain w/ C++, NPTL
+#
+
+#
+# ser2net needs a toolchain w/ IPv6
+#
+# BR2_PACKAGE_SHAIRPORT_SYNC is not set
+
+#
+# smcroute needs a toolchain w/ IPv6
+#
 # BR2_PACKAGE_SOCAT is not set
 # BR2_PACKAGE_SOCKETCAND is not set
 # BR2_PACKAGE_SPAWN_FCGI is not set
+
+#
+# spice server needs a toolchain w/ wchar, threads
+#
 
 #
 # spice server depends on python (for pyparsing)
@@ -1311,8 +2064,9 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_SPICE_PROTOCOL is not set
 
 #
-# squid needs a toolchain w/ C++, IPv6
+# squid needs a toolchain w/ C++, IPv6, headers >= 3.0
 #
+# BR2_PACKAGE_SSHPASS is not set
 # BR2_PACKAGE_STRONGSWAN is not set
 # BR2_PACKAGE_STUNNEL is not set
 # BR2_PACKAGE_TCPDUMP is not set
@@ -1321,19 +2075,36 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_THTTPD is not set
 # BR2_PACKAGE_TINYHTTPD is not set
 # BR2_PACKAGE_TN5250 is not set
-# BR2_PACKAGE_TRANSMISSION is not set
-# BR2_PACKAGE_TVHEADEND is not set
-# BR2_PACKAGE_UDPCAST is not set
-# BR2_PACKAGE_ULOGD is not set
-# BR2_PACKAGE_USHARE is not set
-# BR2_PACKAGE_USSP_PUSH is not set
+
+#
+# transmission needs a toolchain w/ IPv6, threads
+#
+
+#
+# tvheadend needs a toolchain w/ largefile, IPv6, NPTL, headers >= 3.2
+#
+
+#
+# udpcast needs a toolchain w/ largefile, threads
+#
+
+#
+# ushare needs a toolchain w/ largefile, threads, dynamic library
+#
+
+#
+# ussp-push needs a toolchain w/ wchar, IPv6, threads, dynamic library
+#
 # BR2_PACKAGE_VDE2 is not set
 # BR2_PACKAGE_VPNC is not set
 # BR2_PACKAGE_VSFTPD is not set
 # BR2_PACKAGE_VTUN is not set
 # BR2_PACKAGE_WIRELESS_REGDB is not set
 # BR2_PACKAGE_WIRELESS_TOOLS is not set
-# BR2_PACKAGE_WIRESHARK is not set
+
+#
+# wireshark needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_WPA_SUPPLICANT is not set
 
 #
@@ -1343,11 +2114,15 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_XL2TP is not set
 
 #
+# znc needs a toolchain w/ C++
+#
+
+#
 # Package managers
 #
 # BR2_PACKAGE_IPKG is not set
 BR2_PACKAGE_OPKG=y
-# BR2_PACKAGE_OPKG_GPG_SIGN is not set
+BR2_PACKAGE_OPKG_GPG_SIGN=y
 
 #
 # Real-Time
@@ -1366,14 +2141,26 @@ BR2_PACKAGE_OPKG=y
 # Utilities
 #
 # BR2_PACKAGE_AT is not set
+# BR2_PACKAGE_CCRYPT is not set
 # BR2_PACKAGE_DIALOG is not set
 # BR2_PACKAGE_DTACH is not set
 # BR2_PACKAGE_FILE is not set
-# BR2_PACKAGE_GNUPG is not set
-# BR2_PACKAGE_INOTIFY_TOOLS is not set
+BR2_PACKAGE_GNUPG=y
+# BR2_PACKAGE_GNUPG_RSA is not set
+# BR2_PACKAGE_GNUPG_GPGV is not set
+# BR2_PACKAGE_GNUPG_GPGSPLIT is not set
+# BR2_PACKAGE_GNUPG2 is not set
+
+#
+# inotify-tools needs a toolchain w/ largefile
+#
 # BR2_PACKAGE_LOCKFILE_PROGS is not set
-# BR2_PACKAGE_LOGROTATE is not set
+
+#
+# logrotate needs a toolchain w/ wchar
+#
 # BR2_PACKAGE_LOGSURFER is not set
+# BR2_PACKAGE_PINENTRY is not set
 # BR2_PACKAGE_SCREEN is not set
 # BR2_PACKAGE_SUDO is not set
 # BR2_PACKAGE_TMUX is not set
@@ -1382,35 +2169,71 @@ BR2_PACKAGE_OPKG=y
 #
 # System tools
 #
-# BR2_PACKAGE_ACL is not set
-# BR2_PACKAGE_ATTR is not set
+
+#
+# acl needs a toolchain w/ largefile
+#
+
+#
+# attr needs a toolchain w/ largefile
+#
 # BR2_PACKAGE_CPULOAD is not set
+
+#
+# ftop needs a toolchain w/ largefile
+#
+# BR2_PACKAGE_GETENT is not set
 # BR2_PACKAGE_HTOP is not set
+# BR2_PACKAGE_IPRUTILS is not set
 # BR2_PACKAGE_KEYUTILS is not set
 # BR2_PACKAGE_KMOD is not set
-# BR2_PACKAGE_LXC is not set
+
+#
+# lxc needs a toolchain w/ IPv6, threads, largefile, headers >= 3.0
+#
 # BR2_PACKAGE_MONIT is not set
 # BR2_PACKAGE_NCDU is not set
-# BR2_PACKAGE_NUMACTL is not set
-# BR2_PACKAGE_NUT is not set
-# BR2_PACKAGE_POLKIT is not set
-# BR2_PACKAGE_QUOTA is not set
+
+#
+# numactl needs a toolchain w/ largefile
+#
+
+#
+# nut needs a toolchain w/ C++
+#
+
+#
+# openvmtools needs a toolchain w/ wchar, threads, RPC, largefile, locale
+#
+
+#
+# polkit needs a toolchain w/ wchar, threads
+#
+# BR2_PACKAGE_PWGEN is not set
+
+#
+# quota needs a toolchain w/ largefile, wchar, threads
+#
+# BR2_PACKAGE_SMACK is not set
 
 #
 # supervisor needs the python interpreter
 #
+BR2_PACKAGE_SYSTEMD_ARCH_SUPPORTS=y
 
 #
-# systemd needs udev /dev management and a toolchain w/ IPv6, threads
+# util-linux needs a toolchain w/ largefile, wchar
 #
-# BR2_PACKAGE_UTIL_LINUX is not set
 
 #
 # Text editors and viewers
 #
 # BR2_PACKAGE_ED is not set
 # BR2_PACKAGE_JOE is not set
-# BR2_PACKAGE_NANO is not set
+
+#
+# nano needs a toolchain w/ wchar
+#
 # BR2_PACKAGE_UEMACS is not set
 
 #
@@ -1440,21 +2263,30 @@ BR2_TARGET_ROOTFS_TAR_NONE=y
 # BR2_TARGET_ROOTFS_TAR_XZ is not set
 BR2_TARGET_ROOTFS_TAR_OPTIONS=""
 # BR2_TARGET_ROOTFS_UBIFS is not set
+# BR2_TARGET_ROOTFS_YAFFS2 is not set
 
 #
 # Bootloaders
 #
 # BR2_TARGET_BAREBOX is not set
 # BR2_TARGET_GRUB is not set
+# BR2_TARGET_GRUB2 is not set
+
+#
+# gummiboot needs a toolchain w/ largefile, wchar
+#
 # BR2_TARGET_SYSLINUX is not set
 # BR2_TARGET_UBOOT is not set
 
 #
 # Host utilities
 #
+# BR2_PACKAGE_HOST_CRAMFS is not set
 # BR2_PACKAGE_HOST_DFU_UTIL is not set
+# BR2_PACKAGE_HOST_DOS2UNIX is not set
 # BR2_PACKAGE_HOST_DOSFSTOOLS is not set
 # BR2_PACKAGE_HOST_E2FSPROGS is not set
+# BR2_PACKAGE_HOST_E2TOOLS is not set
 # BR2_PACKAGE_HOST_GENEXT2FS is not set
 # BR2_PACKAGE_HOST_GENIMAGE is not set
 # BR2_PACKAGE_HOST_GENPART is not set
@@ -1463,6 +2295,8 @@ BR2_TARGET_ROOTFS_TAR_OPTIONS=""
 # BR2_PACKAGE_HOST_MTOOLS is not set
 # BR2_PACKAGE_HOST_OPENOCD is not set
 # BR2_PACKAGE_HOST_PARTED is not set
+# BR2_PACKAGE_HOST_PATCHELF is not set
+# BR2_PACKAGE_HOST_PWGEN is not set
 # BR2_PACKAGE_HOST_SAM_BA is not set
 # BR2_PACKAGE_HOST_SQUASHFS is not set
 # BR2_PACKAGE_HOST_UBOOT_TOOLS is not set
@@ -1471,6 +2305,62 @@ BR2_TARGET_ROOTFS_TAR_OPTIONS=""
 #
 # Legacy config options
 #
+
+#
+# Legacy options removed in 2014.11
+#
+# BR2_x86_generic is not set
+# BR2_GCC_VERSION_4_4_X is not set
+# BR2_sparc_sparchfleon is not set
+# BR2_sparc_sparchfleonv8 is not set
+# BR2_sparc_sparcsfleon is not set
+# BR2_sparc_sparcsfleonv8 is not set
+# BR2_PACKAGE_LINUX_FIRMWARE_XC5000 is not set
+# BR2_PACKAGE_LINUX_FIRMWARE_CXGB4 is not set
+# BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_3160_7260_7 is not set
+# BR2_PACKAGE_LINUX_FIRMWARE_IWLWIFI_3160_7260_8 is not set
+
+#
+# Legacy options removed in 2014.08
+#
+# BR2_PACKAGE_LIBELF is not set
+# BR2_KERNEL_HEADERS_3_8 is not set
+# BR2_PACKAGE_GETTEXT_TOOLS is not set
+# BR2_PACKAGE_PROCPS is not set
+# BR2_BINUTILS_VERSION_2_20_1 is not set
+# BR2_BINUTILS_VERSION_2_21 is not set
+# BR2_BINUTILS_VERSION_2_23_1 is not set
+# BR2_UCLIBC_VERSION_0_9_32 is not set
+# BR2_GCC_VERSION_4_3_X is not set
+# BR2_GCC_VERSION_4_6_X is not set
+# BR2_GDB_VERSION_7_4 is not set
+# BR2_GDB_VERSION_7_5 is not set
+# BR2_BUSYBOX_VERSION_1_19_X is not set
+# BR2_BUSYBOX_VERSION_1_20_X is not set
+# BR2_BUSYBOX_VERSION_1_21_X is not set
+# BR2_PACKAGE_LIBV4L_DECODE_TM6000 is not set
+# BR2_PACKAGE_LIBV4L_IR_KEYTABLE is not set
+# BR2_PACKAGE_LIBV4L_V4L2_COMPLIANCE is not set
+# BR2_PACKAGE_LIBV4L_V4L2_CTL is not set
+# BR2_PACKAGE_LIBV4L_V4L2_DBG is not set
+
+#
+# Legacy options removed in 2014.05
+#
+# BR2_PACKAGE_EVTEST_CAPTURE is not set
+# BR2_KERNEL_HEADERS_3_6 is not set
+# BR2_KERNEL_HEADERS_3_7 is not set
+# BR2_PACKAGE_VALA is not set
+BR2_PACKAGE_TZDATA_ZONELIST=""
+# BR2_PACKAGE_LUA_INTERPRETER_EDITING_NONE is not set
+# BR2_PACKAGE_LUA_INTERPRETER_READLINE is not set
+# BR2_PACKAGE_LUA_INTERPRETER_LINENOISE is not set
+# BR2_PACKAGE_DVB_APPS_UTILS is not set
+# BR2_KERNEL_HEADERS_SNAP is not set
+# BR2_ROOTFS_DEVICE_CREATION_DYNAMIC_UDEV is not set
+# BR2_PACKAGE_UDEV is not set
+# BR2_PACKAGE_UDEV_RULES_GEN is not set
+# BR2_PACKAGE_UDEV_ALL_EXTRAS is not set
 
 #
 # Legacy options removed in 2014.02
@@ -1546,6 +2436,7 @@ BR2_LINUX_KERNEL_CUSTOM_GIT_VERSION=""
 # BR2_PACKAGE_CUSTOMIZE is not set
 # BR2_PACKAGE_XSERVER_xorg is not set
 # BR2_PACKAGE_XSERVER_tinyx is not set
+# BR2_PACKAGE_PTHREAD_STUBS is not set
 
 #
 # Legacy options removed in 2012.08

--- a/package/nginx/nginx.mk
+++ b/package/nginx/nginx.mk
@@ -9,7 +9,7 @@ NGINX_SITE = http://nginx.org/download
 NGINX_LICENSE = BSD-2c
 NGINX_LICENSE_FILES = LICENSE
 
-NGINX_CONF_OPT = \
+NGINX_CONF_OPTS = \
 	--crossbuild=Linux::$(BR2_ARCH) \
 	--with-cc="$(TARGET_CC)" \
 	--with-cpp="$(TARGET_CC)" \
@@ -44,7 +44,7 @@ NGINX_CONF_ENV += \
 	ngx_force_have_sysvshm=yes \
 	ngx_force_have_posix_sem=yes
 
-NGINX_CONF_OPT += \
+NGINX_CONF_OPTS += \
 	--prefix=/etc/nginx \
 	--conf-path=/etc/nginx/nginx.conf \
 	--sbin-path=/usr/bin/nginx \
@@ -60,15 +60,15 @@ NGINX_CONF_OPT += \
 	--http-scgi-temp-path=/var/lib/nginx/scgi \
 	--http-uwsgi-temp-path=/var/lib/nginx/uwsgi
 
-NGINX_CONF_OPT += \
+NGINX_CONF_OPTS += \
 	$(if $(BR2_PACKAGE_NGINX_FILE_AIO),--with-file-aio) \
 	$(if $(BR2_INET_IPV6),--with-ipv6)
 
 ifeq ($(BR2_PACKAGE_PCRE),y)
 NGINX_DEPENDENCIES += pcre
-NGINX_CONF_OPT += --with-pcre
+NGINX_CONF_OPTS += --with-pcre
 else
-NGINX_CONF_OPT += --without-pcre
+NGINX_CONF_OPTS += --without-pcre
 endif
 
 # modules disabled or not activated because of missing dependencies:
@@ -78,13 +78,13 @@ endif
 # - pcre-jit          (want to rebuild pcre)
 
 # misc. modules
-NGINX_CONF_OPT += \
+NGINX_CONF_OPTS += \
 	$(if $(BR2_PACKAGE_NGINX_rtsig_module),--with-rtsig_module) \
 	$(if $(BR2_PACKAGE_NGINX_select_module),--with-select_module,--without-select_module) \
 	$(if $(BR2_PACKAGE_NGINX_poll_module),--with-poll_module,--without-poll_module)
 
 ifneq ($(BR2_PACKAGE_NGINX_add_modules),)
-NGINX_CONF_OPT += \
+NGINX_CONF_OPTS += \
 	$(addprefix --add-module=,$(call qstrip,$(BR2_PACKAGE_NGINX_add_modules)))
 endif
 
@@ -93,54 +93,54 @@ ifeq ($(BR2_PACKAGE_NGINX_HTTP),y)
 ifeq ($BR2_PACKAGE_NGINX_http_cache),y)
 NGINX_DEPENDENCIES += openssl
 else
-NGINX_CONF_OPT += --without-http-cache
+NGINX_CONF_OPTS += --without-http-cache
 endif
 
 ifeq ($(BR2_PACKAGE_OPENSSL),y)
 NGINX_DEPENDENCIES += openssl
-NGINX_CONF_OPT += --with-http_ssl_module
+NGINX_CONF_OPTS += --with-http_ssl_module
 endif
 
 ifeq ($(BR2_PACKAGE_NGINX_http_xslt_module),y)
 NGINX_DEPENDENCIES += libxml2 libxslt
-NGINX_CONF_OPT += --with-http_xslt_module
+NGINX_CONF_OPTS += --with-http_xslt_module
 NGINX_CONF_ENV += \
 	ngx_feature_path_libxslt=$(STAGING_DIR)/usr/include/libxml2
 endif
 
 ifeq ($(BR2_PACKAGE_NGINX_http_image_filter_module),y)
 NGINX_DEPENDENCIES += gd jpeg libpng
-NGINX_CONF_OPT += --with-http_image_filter_module
+NGINX_CONF_OPTS += --with-http_image_filter_module
 endif
 
 ifeq ($(BR2_PACKAGE_NGINX_http_gunzip_module),y)
 NGINX_DEPENDENCIES += zlib
-NGINX_CONF_OPT += --with-http_gunzip_module
+NGINX_CONF_OPTS += --with-http_gunzip_module
 endif
 
 ifeq ($(BR2_PACKAGE_NGINX_http_gzip_static_module),y)
 NGINX_DEPENDENCIES += zlib
-NGINX_CONF_OPT += --with-http_gzip_static_module
+NGINX_CONF_OPTS += --with-http_gzip_static_module
 endif
 
 ifeq ($(BR2_PACKAGE_NGINX_http_secure_link_module),y)
 NGINX_DEPENDENCIES += openssl
-NGINX_CONF_OPT += --with-http_secure_link_module
+NGINX_CONF_OPTS += --with-http_secure_link_module
 endif
 
 ifeq ($(BR2_PACKAGE_NGINX_http_gzip_module),y)
 NGINX_DEPENDENCIES += zlib
 else
-NGINX_CONF_OPT += --without-http_gzip_module
+NGINX_CONF_OPTS += --without-http_gzip_module
 endif
 
 ifeq ($(BR2_PACKAGE_NGINX_http_rewrite_module),y)
 NGINX_DEPENDENCIES += pcre
 else
-NGINX_CONF_OPT += --without-http_rewrite_module
+NGINX_CONF_OPTS += --without-http_rewrite_module
 endif
 
-NGINX_CONF_OPT += \
+NGINX_CONF_OPTS += \
 	$(if $(BR2_PACKAGE_NGINX_http_spdy_module),--with-http_spdy_module) \
 	$(if $(BR2_PACKAGE_NGINX_http_realip_module),--with-http_realip_module) \
 	$(if $(BR2_PACKAGE_NGINX_http_addition_module),--with-http_addition_module) \
@@ -176,7 +176,7 @@ NGINX_CONF_OPT += \
 	$(if $(BR2_PACKAGE_NGINX_http_upstream_keepalive_module),,--without-http_upstream_keepalive_module)
 
 else # !BR2_PACKAGE_NGINX_HTTP
-NGINX_CONF_OPT += --without-http
+NGINX_CONF_OPTS += --without-http
 endif # BR2_PACKAGE_NGINX_HTTP
 
 # mail modules
@@ -184,10 +184,10 @@ ifeq ($BR2_PACKAGE_NGINX_MAIL),y)
 
 ifeq ($(BR2_PACKAGE_OPENSSL),y)
 NGINX_DEPENDENCIES += openssl
-NGINX_CONF_OPT += --with-mail_ssl_module
+NGINX_CONF_OPTS += --with-mail_ssl_module
 endif
 
-NGINX_CONF_OPT += \
+NGINX_CONF_OPTS += \
 	$(if $(BR2_PACKAGE_NGINX_mail_pop3_module),,--without-mail_pop3_module) \
 	$(if $(BR2_PACKAGE_NGINX_mail_imap_module),,--without-mail_imap_module) \
 	$(if $(BR2_PACKAGE_NGINX_mail_smtp_module),,--without-mail_smtp_module)
@@ -200,7 +200,7 @@ endef
 NGINX_PRE_CONFIGURE_HOOKS += NGINX_DISABLE_WERROR
 
 define NGINX_CONFIGURE_CMDS
-	cd $(@D) ; $(NGINX_CONF_ENV) ./configure $(NGINX_CONF_OPT)
+	cd $(@D) ; $(NGINX_CONF_ENV) ./configure $(NGINX_CONF_OPTS)
 endef
 
 define NGINX_BUILD_CMDS


### PR DESCRIPTION
The only changes made to the default buildroot config are:

 - target options -> architecture
BR2_x86_64

 - target packages -> package managers -> opkg
BR2_PACKAGE_OPKG
BR2_PACKAGE_OPKG_GPG_SIGN


I propose also enabling the following settings, but in a separate pull request:

 - build options -> enable compiler cache
BR2_CCACHE
If I remember it correctly from compilation of OpenWRT, using the compiler cache can speed up compilation significantly on recompilation. This would possibly require setting up a docker volume, so different compilation runs can see the same cache.

 - build options -> gcc optimization level
BR2_OPTIMIZE_3
I understand that reducing the container size is the main goal of this project. However, if using the busybox container on a server, speed may be important, too. Especially, I think this settings is used for compilation of libc itself, which is thus 'inherited' by all other packages.

 - toolchain -> enable stack protection support
BR2_TOOLCHAIN_BUILDROOT_USE_SSP
Hardening.

 - system configuration -> passwords encoding
BR2_TARGET_GENERIC_PASSWD_SHA512
Buildroot's default is md5, which is considered weak. Should really be changed upstream.