### PR TITLE
Fix container name: use `progrium/rootbuilder` instead of `rootbuilder`

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -1,7 +1,7 @@
 .PHONY: config
 
 config:
-	docker run -it rootbuilder make nconfig
+	docker run -it progrium/rootbuilder make nconfig
 	docker cp `docker ps -lq`:/tmp/buildroot/.config .
 	docker rm `docker ps -lq`
 	mv .config config


### PR DESCRIPTION
There does not seem to exist a container named `rootbuilder`, as shown
by the search:
https://registry.hub.docker.com/search?q=rootbuilder

Error message was:

```
$ cd example && make config

docker run -it rootbuilder make nconfig
Unable to find image 'rootbuilder:latest' locally
Pulling repository rootbuilder
FATA[0004] Error: image library/rootbuilder:latest not found
make: *** [config] Error 1
```
